### PR TITLE
Update the README to cover how to get started with this firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,87 @@
 # Ambi Client (C++)
 
-An IoT sensor platform based on the [Particle IoT Air Quality Monitoring Kit](https://store.particle.io/products/air-quality-monitoring-kit-wi-fi).
+An Edge IoT ambient room environment sensor implementation for a [Particle Argon](https://docs.particle.io/argon/) based on the [Particle IoT Air Quality Monitoring Kit](https://store.particle.io/products/air-quality-monitoring-kit-wi-fi).
 
-## Welcome to your project!
+This client pairs with and pushes readings to a [Ambi web backend instance](https://github.com/Jim-Hodapp-Coaching/ambi).
 
-Every new Particle project is composed of 3 important elements that you'll see have been created in your project directory for sensorchi.
+## Compiling this firmware using the Particle CLI
 
-#### ```/src``` folder:  
-This is the source folder that contains the firmware files for your project. It should *not* be renamed. 
-Anything that is in this folder when you compile your project will be sent to our compile service and compiled into a firmware binary for the Particle device that you have targeted.
+When you're ready to compile this firmware, make sure you have the [Particle CLI installed](https://docs.particle.io/tutorials/developer-tools/cli/) and also make sure you have the Particle Argon device target selected and run `particle compile <platform>` in the CLI. Note: if you're on an Arm-based Mac, the default Particle CLI install doesn't seem to work right. Work around this by doing a more manual install by running `sudo npm install -g particle-cli`.
 
-If your application contains multiple files, they should all be included in the `src` folder. If your firmware depends on Particle libraries, those dependencies are specified in the `project.properties` file referenced below.
+Also make sure that you have an account registered with the Particle cloud and you've logged in using `particle setup`.
 
-#### ```.ino``` file:
-This file is the firmware that will run as the primary application on your Particle device. It contains a `setup()` and `loop()` function, and can be written in Wiring or C/C++. For more information about using the Particle firmware API to create firmware for your Particle device, refer to the [Firmware Reference](https://docs.particle.io/reference/firmware/) section of the Particle documentation.
+To build:
+`particle compile argon --saveTo ambi_client_cpp.bin`
 
-#### ```project.properties``` file:  
-This is the file that specifies the name and version number of the libraries that your project depends on. Dependencies are added automatically to your `project.properties` file when you add a library to a project using the `particle library add` command in the CLI or add a library in the Desktop IDE.
+If building succeeds, you'll see output similar to:
 
-## Adding additional files to your project
+```
+Compiling code for argon
 
-#### Projects with multiple sources
-If you would like add additional files to your application, they should be added to the `/src` folder. All files in the `/src` folder will be sent to the Particle Cloud to produce a compiled binary.
+Including:
+    src/air_purity_sensor.h
+    src/base_sensor.h
+    src/dust_sensor.h
+    src/http_client.h
+    src/humidity_sensor.h
+    src/pressure_sensor.h
+    src/temperature_sensor.h
+    src/sensorchi.ino
+    src/air_purity_sensor.cpp
+    src/base_sensor.cpp
+    src/dust_sensor.cpp
+    src/http_client.cpp
+    src/humidity_sensor.cpp
+    src/pressure_sensor.cpp
+    src/sensorchi.cpp
+    src/temperature_sensor.cpp
+    project.properties
 
-#### Projects with external libraries
-If your project includes a library that has not been registered in the Particle libraries system, you should create a new folder named `/lib/<libraryname>/src` under `/<project dir>` and add the `.h`, `.cpp` & `library.properties` files for your library there. Read the [Firmware Libraries guide](https://docs.particle.io/guide/tools-and-features/libraries/) for more details on how to develop libraries. Note that all contents of the `/lib` folder and subfolders will also be sent to the Cloud for compilation.
+attempting to compile firmware
+downloading binary from: /v1/binaries/621006549bdb2a2cea6cc276
+saving to: ambi_client_cpp.bin
+Memory use:
+   text    data     bss     dec     hex filename
+  34080     128    2324   36532    8eb4 /workspace/target/workspace.elf
 
-## Compiling your project
+Compile succeeded.
+Saved firmware to: /Users/jhodapp/Projects/cpp/ambi_client_cpp/ambi_client_cpp.bin
+```
 
-When you're ready to compile your project, make sure you have the correct Particle device target selected and run `particle compile <platform>` in the CLI or click the Compile button in the Desktop IDE. The following files in your project folder will be sent to the compile service:
+The following files in project folder will be sent to the cloud-hosted compile service:
 
-- Everything in the `/src` folder, including your `.ino` application file
-- The `project.properties` file for your project
-- Any libraries stored under `lib/<libraryname>/src`
+- Everything in the `/src` folder, including the `.ino` application file
+- The `project.properties` project definition file
+- All libraries stored under `lib/<libraryname>/src`
+
+## Flashing firmware onto Argon target device
+
+To flash your intended Particle Argon target device with the built firmware, first identify the name of the device registered to the Particle cloud by listing all devices:
+
+`particle list`
+
+You should see a list similar to:
+
+```
+ambi1 [e00fce68834a01fd162abace] (Argon) is online
+ambi2 [e00fce68d002c229a830d87f] (Argon) is offline
+  Functions:
+    int digitalread (String args) 
+    int digitalwrite (String args) 
+    int analogread (String args) 
+    int analogwrite (String args) 
+```
+
+Note: in this example each target already has a specific name (e.g. ambi1) because it was changed via the Particle mobile app. By default you'll have a more generic device target name if using a new Argon from the factory.
+
+Now flash the firmware to your particle device target like so:
+
+`particle flash ambi1 ambi_client_cpp.bin`
+
+Note: again, make sure you replace `ambi1` with your particular device name.
+
+# Changing the firmware to point to your Ambi instance
+
+An important step is to make sure that the firmware points to the local IP address of your Ambi web backend. To do that, open the source file `src/sensorchi.ino` and change one or both of the byte arrays `dev_server` or `prod_server`. Note: at this time, full domain or hostnames are not supported and is future work to improve this firmware once Ambi is fully cloud-hosted.
+
+Now rebuild and reflash your firmware with it pointing to your local Ambi instance. One tip is to either dedicate a small computer like a Raspberry Pi to host the Ambi backend, or host it in a VM or bare on your development computer. Set your WiFi router to always issue your Ambi host the same IP address based on its MAC address. This way you won't have to keep changing the dev/prod IP address.

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -147,6 +147,8 @@ uint16_t HttpClient::payloadLength(const JsonWriterStatic<JSON_WRITER_BUFFER_SIZ
         if (buf[i] == '}')
             return i+1;
     }
+
+    return 0;
 }
 
 bool HttpClient::httpResponseEnd()


### PR DESCRIPTION
Update the README to cover how to get started, compile and flash the firmware onto a Particle Argon target device. Also fix one compile issue arising from a stricter C++ compiler used by Particle.